### PR TITLE
Alternative pins are not avaliable after FlexCan started on Teensy 3.5 an 3.6

### DIFF
--- a/FlexCAN_T4.tpp
+++ b/FlexCAN_T4.tpp
@@ -573,10 +573,10 @@ FCTP_FUNC void FCTP_OPT::setTX(FLEXCAN_PINS pin) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
   if ( _bus == CAN0 ) {
     if ( pin == ALT ) {
-      CORE_PIN3_CONFIG = 0; CORE_PIN29_CONFIG = PORT_PCR_MUX(2);
+      CORE_PIN3_CONFIG = PORT_PCR_MUX(1); CORE_PIN29_CONFIG = PORT_PCR_MUX(2);
     }
     else if ( pin == DEF ) {
-      CORE_PIN29_CONFIG = 0; CORE_PIN3_CONFIG = PORT_PCR_MUX(2);
+      CORE_PIN29_CONFIG = PORT_PCR_MUX(1); CORE_PIN3_CONFIG = PORT_PCR_MUX(2);
     }
   } /* Alternative CAN1 pins are not broken out on Teensy 3.6 */
 #endif
@@ -641,10 +641,10 @@ FCTP_FUNC void FCTP_OPT::setRX(FLEXCAN_PINS pin) {
 #if defined(__MK64FX512__) || defined(__MK66FX1M0__)
   if ( _bus == CAN0 ) {
     if ( pin == ALT ) {
-      CORE_PIN4_CONFIG = 0; CORE_PIN30_CONFIG = PORT_PCR_MUX(2);
+      CORE_PIN4_CONFIG = PORT_PCR_MUX(1); CORE_PIN30_CONFIG = PORT_PCR_MUX(2);
     }
     else if ( pin == DEF ) {
-      CORE_PIN30_CONFIG = 0; CORE_PIN4_CONFIG = PORT_PCR_MUX(2);
+      CORE_PIN30_CONFIG = PORT_PCR_MUX(1); CORE_PIN4_CONFIG = PORT_PCR_MUX(2);
     }
   } /* Alternative CAN1 pins are not broken out on Teensy 3.6 */
 #endif


### PR DESCRIPTION
ALT pins not available as GIO pins after CAN started.
Pin 29 and 30 affected on Teensy 3.5 and 3.6

PR ALT_35_36 raised with a fix in
FlexCAN_T4.tpp lines 576, 579, 644, 647 I believe are wrong as pins set to 0
pins should be reset back to GPIO state using PORT_PCR_MUX(1)