### PR TITLE
Updates for ISOTP write

### DIFF
--- a/isotp.h
+++ b/isotp.h
@@ -101,7 +101,7 @@ ISOTP_CLASS class isotp : public isotp_Base {
     void enable(bool yes = 1) { isotp_enabled = yes; }
     void setPadding(uint8_t _byte) { padding_value = _byte; }
     void onReceive(_isotp_cb_ptr handler) { _ISOTP_OBJ->_isotp_handler = handler; }
-    void write(const ISOTP_data &config, const uint8_t *buf) {write(config, buf, config.len); };
+    void write(const ISOTP_data &config, const uint8_t *buf) { write(config, buf, config.len); };
     void write(const ISOTP_data &config, const uint8_t *buf, uint16_t size);
     void write(const ISOTP_data &config, const char *buf) { write(config, (const uint8_t*)buf, config.len); }
     void write(const ISOTP_data &config, const char *buf, uint16_t size) { write(config, (const uint8_t*)buf, size); }

--- a/isotp.h
+++ b/isotp.h
@@ -101,7 +101,9 @@ ISOTP_CLASS class isotp : public isotp_Base {
     void enable(bool yes = 1) { isotp_enabled = yes; }
     void setPadding(uint8_t _byte) { padding_value = _byte; }
     void onReceive(_isotp_cb_ptr handler) { _ISOTP_OBJ->_isotp_handler = handler; }
+    void write(const ISOTP_data &config, const uint8_t *buf) {write(config, buf, config.len); };
     void write(const ISOTP_data &config, const uint8_t *buf, uint16_t size);
+    void write(const ISOTP_data &config, const char *buf) { write(config, (const uint8_t*)buf, config.len); }
     void write(const ISOTP_data &config, const char *buf, uint16_t size) { write(config, (const uint8_t*)buf, size); }
     void sendFlowControl(const ISOTP_data &config);
 

--- a/isotp.tpp
+++ b/isotp.tpp
@@ -60,11 +60,11 @@ ISOTP_FUNC void ISOTP_OPT::sendFlowControl(const ISOTP_data &config) {
 ISOTP_FUNC void ISOTP_OPT::write(const ISOTP_data &config, const uint8_t *buf, uint16_t size) {
   CAN_message_t msg;
   msg.id = config.id;
-  msg.len = config.len;
+  msg.len = (size < 6) ? size + 2 : 8;
   msg.flags.extended = config.flags.extended;
   msg.buf[0] = (1U << 4) | size >> 8;
   msg.buf[1] = (uint8_t)size;
-  memmove(&msg.buf[2], &buf[0], 6);
+  memmove(&msg.buf[2], &buf[0], (size < 6) ? size : 6);
   _isotp_busToWrite->write(msg);
 
 	


### PR DESCRIPTION
Fixed issue in ISOTP_OPT::write where config.len was being used incorrectly and would not work if set to something different than the default value of 8. It was incorrectly being used to set the length of the first ISO-TP CAN frame. 

Added function prototypes to use config.len as the message length definition rather than having to specify size separately. Makes more sense to specify it in the config. This will not change the behavior of the existing functions so will not effect compatibility but provides a better option.