### PR TITLE
isotp add read bus functionality

### DIFF
--- a/FlexCAN_T4.h
+++ b/FlexCAN_T4.h
@@ -329,6 +329,9 @@ class FlexCAN_T4_Base {
     virtual int write(const CAN_message_t &msg) = 0;
     virtual bool isFD() = 0;
     virtual uint8_t getFirstTxBoxSize();
+    virtual uint8_t getBusNumber();
+  protected:
+    uint8_t busNumber;
 };
 
 #if defined(__IMXRT1062__)
@@ -391,6 +394,7 @@ FCTPFD_CLASS class FlexCAN_T4FD : public FlexCAN_T4_Base {
     void disableDMA() { enableDMA(0); }
     uint8_t getFirstTxBoxSize();
     void setMBFilterProcessing(FLEXCAN_MAILBOX mb_num, uint32_t filter_id, uint32_t calculated_mask);
+    uint8_t getBusNumber() { return busNumber; }
 
   private:
     uint64_t readIFLAG() { return (((uint64_t)FLEXCANb_IFLAG2(_bus) << 32) | FLEXCANb_IFLAG1(_bus)); }
@@ -416,7 +420,6 @@ FCTPFD_CLASS class FlexCAN_T4FD : public FlexCAN_T4_Base {
     void softReset();
     void writeIMASK(uint64_t value);
     void writeIMASKBit(uint8_t mb_num, bool set = 1);
-    uint8_t busNumber;
     uint8_t mailbox_reader_increment = 0;
     uint32_t nvicIrq = 0; 
     uint8_t dlc_to_len(uint8_t val); 
@@ -511,6 +514,7 @@ FCTP_CLASS class FlexCAN_T4 : public FlexCAN_T4_Base {
     bool error(CAN_error_t &error, bool printDetails);
     uint32_t getRXQueueCount() { return rxBuffer.size(); }
     uint32_t getTXQueueCount() { return txBuffer.size(); }
+    uint8_t getBusNumber() { return busNumber; }
 
   private:
     void setMBFilterProcessing(FLEXCAN_MAILBOX mb_num, uint32_t filter_id, uint32_t calculated_mask);
@@ -551,7 +555,6 @@ FCTP_CLASS class FlexCAN_T4 : public FlexCAN_T4_Base {
     uint32_t nvicIrq = 0; 
     uint32_t currentBitrate = 0UL;
     uint8_t mailbox_reader_increment = 0;
-    uint8_t busNumber;
     void mbCallbacks(const FLEXCAN_MAILBOX &mb_num, const CAN_message_t &msg);
 };
 

--- a/isotp.h
+++ b/isotp.h
@@ -93,7 +93,7 @@ ISOTP_CLASS class isotp : public isotp_Base {
     isotp() { _ISOTP_OBJ = this; }
 
 #if defined(TEENSYDUINO) // Teensy
-    void setWriteBus(FlexCAN_T4_Base* _busWritePtr) { _isotp_busToWrite = _busWritePtr; }
+    void setWriteBus(FlexCAN_T4_Base* _busWritePtr) { _isotp_busToWrite = _busWritePtr; readBusNumber = _busWritePtr->getBusNumber(); }
 #elif defined(ARDUINO_ARCH_ESP32) //ESP32
     void setWriteBus(ESP32_CAN_Base* _busWritePtr) { _isotp_busToWrite = _busWritePtr; }
 #endif
@@ -110,6 +110,7 @@ ISOTP_CLASS class isotp : public isotp_Base {
     Circular_Buffer<uint8_t, _rxBanks, _max_length> _rx_slots;
     uint8_t padding_value = 0xA5;
     volatile bool isotp_enabled = 0;
+    uint8_t readBusNumber = 0xff;
 };
 
 #include "isotp.tpp"

--- a/isotp.tpp
+++ b/isotp.tpp
@@ -106,6 +106,8 @@ extern void __attribute__((weak)) ext_isotp_output1(const ISOTP_data &config, co
 ISOTP_FUNC void ISOTP_OPT::_process_frame_data(const CAN_message_t &msg) {
   if ( !isotp_enabled ) return;
 
+  if ( msg.bus != readBusNumber ) return;
+
   if ( msg.buf[0] <= 7 ) { /* single frame */
     ISOTP_data config;
     config.id = msg.id;


### PR DESCRIPTION
Added functionality to set isotp read bus to the isotp write bus to avoid conflicts when multiple can buses are in use.
Solves #34 
Not sure if this is the best way to do it but it does work and should be backwards compatible.

Might have to change your ESP32 library though to support...