### PR TITLE
Isotp add a read bus filter

### DIFF
--- a/isotp.h
+++ b/isotp.h
@@ -93,7 +93,18 @@ ISOTP_CLASS class isotp : public isotp_Base {
     isotp() { _ISOTP_OBJ = this; }
 
 #if defined(TEENSYDUINO) // Teensy
-    void setWriteBus(FlexCAN_T4_Base* _busWritePtr) { _isotp_busToWrite = _busWritePtr; }
+    void setWriteBus(FlexCAN_T4_Base* _busWritePtr) { 
+      _isotp_busToWrite = _busWritePtr; 
+      #if defined(__IMXRT1062__)
+      if ( _isotp_busToWrite == _CAN1 ) readBus = 1;    
+      if ( _isotp_busToWrite == _CAN2 ) readBus = 2;
+      if ( _isotp_busToWrite == _CAN3 ) readBus = 3;
+      #endif
+      #if defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+      if ( _isotp_busToWrite == _CAN0 ) readBus = 0;    
+      if ( _isotp_busToWrite == _CAN1 ) readBus = 1;
+      #endif
+    }
 #elif defined(ARDUINO_ARCH_ESP32) //ESP32
     void setWriteBus(ESP32_CAN_Base* _busWritePtr) { _isotp_busToWrite = _busWritePtr; }
 #endif
@@ -110,6 +121,7 @@ ISOTP_CLASS class isotp : public isotp_Base {
     Circular_Buffer<uint8_t, _rxBanks, _max_length> _rx_slots;
     uint8_t padding_value = 0xA5;
     volatile bool isotp_enabled = 0;
+    uint8_t readBus;
 };
 
 #include "isotp.tpp"

--- a/isotp.h
+++ b/isotp.h
@@ -96,13 +96,13 @@ ISOTP_CLASS class isotp : public isotp_Base {
     void setWriteBus(FlexCAN_T4_Base* _busWritePtr) { 
       _isotp_busToWrite = _busWritePtr; 
       #if defined(__IMXRT1062__)
-      if ( _isotp_busToWrite == _CAN1 ) readBus = 1;    
-      if ( _isotp_busToWrite == _CAN2 ) readBus = 2;
-      if ( _isotp_busToWrite == _CAN3 ) readBus = 3;
+        if ( _isotp_busToWrite == _CAN1 ) readBus = 1;    
+        if ( _isotp_busToWrite == _CAN2 ) readBus = 2;
+        if ( _isotp_busToWrite == _CAN3 ) readBus = 3;
       #endif
       #if defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
-      if ( _isotp_busToWrite == _CAN0 ) readBus = 0;    
-      if ( _isotp_busToWrite == _CAN1 ) readBus = 1;
+        if ( _isotp_busToWrite == _CAN0 ) readBus = 0;    
+        if ( _isotp_busToWrite == _CAN1 ) readBus = 1;
       #endif
     }
 #elif defined(ARDUINO_ARCH_ESP32) //ESP32
@@ -121,7 +121,7 @@ ISOTP_CLASS class isotp : public isotp_Base {
     Circular_Buffer<uint8_t, _rxBanks, _max_length> _rx_slots;
     uint8_t padding_value = 0xA5;
     volatile bool isotp_enabled = 0;
-    uint8_t readBus;
+    uint8_t readBus = 1;
 };
 
 #include "isotp.tpp"

--- a/isotp.tpp
+++ b/isotp.tpp
@@ -106,7 +106,9 @@ extern void __attribute__((weak)) ext_isotp_output1(const ISOTP_data &config, co
 ISOTP_FUNC void ISOTP_OPT::_process_frame_data(const CAN_message_t &msg) {
   if ( !isotp_enabled ) return;
 
+#if defined(TEENSYDUINO)
   if ( msg.bus != readBus ) return;
+#endif
 
   if ( msg.buf[0] <= 7 ) { /* single frame */
     ISOTP_data config;

--- a/isotp.tpp
+++ b/isotp.tpp
@@ -106,6 +106,8 @@ extern void __attribute__((weak)) ext_isotp_output1(const ISOTP_data &config, co
 ISOTP_FUNC void ISOTP_OPT::_process_frame_data(const CAN_message_t &msg) {
   if ( !isotp_enabled ) return;
 
+  if ( msg.bus != readBus ) return;
+
   if ( msg.buf[0] <= 7 ) { /* single frame */
     ISOTP_data config;
     config.id = msg.id;


### PR DESCRIPTION
Added a filter to only process isotp frames from the same bus as the write bus. This avoids conflicts when multiple CAN buses are enabled. Solves issue #34