### PR TITLE
Added padding for isotp single frames

### DIFF
--- a/isotp.tpp
+++ b/isotp.tpp
@@ -65,6 +65,11 @@ ISOTP_FUNC void ISOTP_OPT::write(const ISOTP_data &config, const uint8_t *buf, u
     msg.len = size + 1;
     msg.buf[0] = size & 0x0f;
     memmove(&msg.buf[1], &buf[0], size);
+   
+    if ( config.flags.usePadding ) {
+      for ( int i = msg.len; i <= 7; i++ ) msg.buf[i] = padding_value;
+      msg.len = 8;
+    }
     _isotp_busToWrite->write(msg);
     return;
   } 


### PR DESCRIPTION
Noticed when I implemented the isotp single frame #31  I didn't implement padding for it.
This adds it