### PR TITLE
Enabling flexcan_interrupt to fire onReceive for CAN-FD

### DIFF
--- a/FlexCAN_T4.h
+++ b/FlexCAN_T4.h
@@ -393,6 +393,7 @@ FCTPFD_CLASS class FlexCAN_T4FD : public FlexCAN_T4_Base {
     void setMBFilterProcessing(FLEXCAN_MAILBOX mb_num, uint32_t filter_id, uint32_t calculated_mask);
 
   private:
+    volatile bool isEventsUsed = 0;
     uint64_t readIFLAG() { return (((uint64_t)FLEXCANb_IFLAG2(_bus) << 32) | FLEXCANb_IFLAG1(_bus)); }
     uint32_t mailbox_offset(uint8_t mailbox, uint8_t &maxsize); 
     void writeTxMailbox(uint8_t mb_num, const CANFD_message_t &msg);

--- a/FlexCAN_T4FD.tpp
+++ b/FlexCAN_T4FD.tpp
@@ -438,6 +438,7 @@ FCTPFD_FUNC void FCTPFD_OPT::mbCallbacks(const FLEXCAN_MAILBOX &mb_num, const CA
     return;
   }
   if ( _mbHandlers[mb_num] ) _mbHandlers[mb_num](msg);
+  if ( _mainHandler ) _mainHandler(msg);
 }
 
 FCTPFD_FUNC void FCTPFD_OPT::flexcan_interrupt() {
@@ -476,6 +477,10 @@ FCTPFD_FUNC void FCTPFD_OPT::flexcan_interrupt() {
 }
 
 FCTPFD_FUNC void FCTPFD_OPT::struct2queueRx(const CANFD_message_t &msg) {
+  if ( !isEventsUsed ) {
+    mbCallbacks((FLEXCAN_MAILBOX)msg.mb, msg);	
+    return;	
+  }
   uint8_t buf[sizeof(CANFD_message_t)];
   memmove(buf, &msg, sizeof(msg));
   rxBuffer.push_back(buf, sizeof(CANFD_message_t));
@@ -504,6 +509,7 @@ FCTPFD_FUNC int FCTPFD_OPT::write(const CANFD_message_t &msg) {
 }
 
 FCTPFD_FUNC uint64_t FCTPFD_OPT::events() {
+  if ( !isEventsUsed ) isEventsUsed = 1;
   if ( rxBuffer.size() ) {
     CANFD_message_t frame;
     uint8_t buf[sizeof(CANFD_message_t)];


### PR DESCRIPTION
Addresses issue #56. Enables onReceive to fire for CAN-FD without requiring calling events. Mimics the CAN2.0 implementation. Tested briefly between two Teensy MMOD boards. Also enables using onReceive with and without the mailbox specifier.